### PR TITLE
Fix Contact Page Banner Behavior

### DIFF
--- a/src/pages/support/contact/index.page.tsx
+++ b/src/pages/support/contact/index.page.tsx
@@ -70,7 +70,7 @@ const ContactsPage: FC = () => {
     return (
         <>
             <section className={cn(styles.section, styles.fullHeightSection)}>
-            <MainBackground url={OFFICE_GIRL_3} />
+            <MainBackground url={OFFICE_GIRL_3} className="!bg-[center_top] sm:!bg-[center_center]"/>
                 
                 <div
                     className={cn(

--- a/src/pages/support/contact/index.page.tsx
+++ b/src/pages/support/contact/index.page.tsx
@@ -73,13 +73,10 @@ const ContactsPage: FC = () => {
             <MainBackground url={OFFICE_GIRL_3} />
                 
                 <div
-                    className={cn('h-dvh max-h-[62.5rem] w-full max-w-[120rem]', 'relative bg-cover bg-center')}
-                    style={{
-                        position: 'relative',
-                        backgroundPosition: '50% top',
-                        backgroundSize: 'cover', 
-                    }}
-                >
+                    className={cn(
+                        styles.content
+                    )}
+                >    
                     <div className={cn(styles.content, 'relative z-10 flex items-start justify-start')}>
                         <div>
                             <h1

--- a/src/pages/support/contact/index.page.tsx
+++ b/src/pages/support/contact/index.page.tsx
@@ -13,6 +13,8 @@ import { ResourcesSection } from '@/app/ui/templates';
 import { PageLink } from '@/app/ui/layout';
 import { Route } from '@/app/static';
 
+import { MainBackground } from '@/app/ui/atoms';
+
 import styles from '@/app/common.module.css';
 
 import OFFICE_GIRL_3 from '@/assets/images/office-girl-3.png';
@@ -67,14 +69,15 @@ const ContactsPage: FC = () => {
 
     return (
         <>
-            <section className={'flex justify-center w-full'}>
+            <section className={cn(styles.section, styles.fullHeightSection)}>
+            <MainBackground url={OFFICE_GIRL_3} />
+                
                 <div
                     className={cn('h-dvh max-h-[62.5rem] w-full max-w-[120rem]', 'relative bg-cover bg-center')}
                     style={{
-                        backgroundImage: `url(${OFFICE_GIRL_3.src})`,
                         position: 'relative',
-                        backgroundSize: 'cover',
                         backgroundPosition: '50% top',
+                        backgroundSize: 'cover', 
                     }}
                 >
                     <div className={cn(styles.content, 'relative z-10 flex items-start justify-start')}>


### PR DESCRIPTION
# Pull Request for Website

## Description
Updated the Contact page banner behavior to match the About and Tidal pages. Previously, the entire top section (including the "Contact Tern" heading) was sticky, causing it to stay pinned during scroll. This was inconsistent with other pages where only the background image remains fixed while the heading scrolls with content.

## Type of Change
Please mark the relevant option(s):
- [✅] Update Feature
- [ ] Add Feature
- [ ] Delete Feature
- [ ] Add File(s)
- [ ] Delete File(s)
- [ ] Other (please specify):

## Checklist:
- [✅] My code adheres to the project guidelines and best practices.
- [✅] I have tested my changes and they work as expected.
- [ ] I have updated the relevant documentation (if applicable).
- [ ] I have added any necessary unit tests.
- [ ] I have checked for and resolved any potential conflicts.
- [ ] I have sent an update to the Discord channel regarding these changes.


