### PR TITLE
fix: Contact page banner remain fixed similar to About and Tidal page

### DIFF
--- a/src/pages/support/contact/index.page.tsx
+++ b/src/pages/support/contact/index.page.tsx
@@ -12,6 +12,7 @@ import { ResourceCard } from '@/app/ui/organisms';
 import { ResourcesSection } from '@/app/ui/templates';
 import { PageLink } from '@/app/ui/layout';
 import { Route } from '@/app/static';
+import { MainBackground } from '@/app/ui/atoms';
 
 import styles from '@/app/common.module.css';
 
@@ -67,33 +68,27 @@ const ContactsPage: FC = () => {
 
     return (
         <>
-            <section className={'flex justify-center w-full'}>
+            <section className={cn(styles.section, styles.fullHeightSection)}>
+                <MainBackground url={OFFICE_GIRL_3.src} />
                 <div
-                    className={cn('h-dvh max-h-[62.5rem] w-full max-w-[120rem]', 'relative bg-cover bg-center')}
-                    style={{
-                        backgroundImage: `url(${OFFICE_GIRL_3.src})`,
-                        position: 'relative',
-                        backgroundSize: 'cover',
-                        backgroundPosition: '50% top',
-                    }}
+                    className={cn(
+                        styles.content,
+                        'relative flex justify-start z-10',
+                        'items-start md:items-center lg:items-center'
+                    )}
                 >
-                    <div className={cn(styles.content, 'relative z-10 flex items-start justify-start')}>
-                        <div>
-                            <h1
-                                className={cn(
-                                    `w-min text-left leading-n`,
-                                    `mb-n text-96`,
-                                    `lg:x-[w-full,mt-6xl-1]`,
-                                    `md:x-[mt-xl,text-96]`,
-                                    `sm:x-[flex,mt-xs,text-64]`,
-                                )}
-                            >
-                                Contact Tern
-                            </h1>
-                        </div>
+                    <div>
+                        <h1
+                            className={cn(
+                                'w-min text-left leading-n mb-n text-96',
+                                'lg:x-[w-full,mt-6xl-1]',
+                                'md:x-[mt-xl,text-96]',
+                                'sm:x-[flex,mt-xs,text-64]'
+                            )}
+                        >
+                            Contact Tern
+                        </h1>
                     </div>
-                    <div className='absolute inset-0 bg-gradient-to-r from-black via-black via-0% lg:via-5% to-transparent  sm:to-60%  md:to-40% lg:to-50% z-0' />
-                    <div className='absolute inset-0 bg-gradient-to-l from-black from-0%   via-black via-0% lg:via-10%   to-transparent to-0% lg:to-20% z-1' />
                 </div>
             </section>
 


### PR DESCRIPTION
# Pull Request for Website

## Description
The PR fixed the Contact page banner to remain fixed until the content below covers them. This ensures the consistency of the banner behavior between the Contact, About, and Tidal pages.

## Type of Change
Please mark the relevant option(s):
- [ X] Update Feature
- [ ] Add Feature
- [ ] Delete Feature
- [ ] Add File(s)
- [ ] Delete File(s)
- [ ] Other (please specify):

## Checklist:
- [ X] My code adheres to the project guidelines and best practices.
- [ X] I have tested my changes and they work as expected.
- [ ] I have updated the relevant documentation (if applicable).
- [ ] I have added any necessary unit tests.
- [ X] I have checked for and resolved any potential conflicts.
- [ X] I have sent an update to the Discord channel regarding these changes.

## Additional Notes:
- I have tested between different sizes of screens like mobile, tablets, and desktops and it functions as expected.
- I have reused the MainBackground component and styles.fullHeightSection for consistency between pages. 