### PR TITLE
fix: make contact page banner image fixed during scroll

### DIFF
--- a/src/pages/support/contact/index.page.tsx
+++ b/src/pages/support/contact/index.page.tsx
@@ -69,10 +69,9 @@ const ContactsPage: FC = () => {
         <>
             <section className={'flex justify-center w-full'}>
                 <div
-                    className={cn('h-dvh max-h-[62.5rem] w-full max-w-[120rem]', 'relative bg-cover bg-center')}
+                    className={cn('h-dvh max-h-[62.5rem] w-full max-w-[120rem]', 'relative bg-cover bg-fixed')}
                     style={{
                         backgroundImage: `url(${OFFICE_GIRL_3.src})`,
-                        position: 'relative',
                         backgroundSize: 'cover',
                         backgroundPosition: '50% top',
                     }}


### PR DESCRIPTION
# Pull Request for Website

## Description
Adjusted the Contact page so that the banner image stays fixed during scrolling. Previously, the image scrolled with the content, unlike the About and Tidal pages. Now, the content scrolls over the banner, creating a consistent user experience across pages.

## Type of Change
Please mark the relevant option(s):
- [x] Update Feature
- [ ] Add Feature
- [ ] Delete Feature
- [ ] Add File(s)
- [ ] Delete File(s)
- [ ] Other (please specify):

## Checklist:
- [x] My code adheres to the project guidelines and best practices.
- [x] I have tested my changes and they work as expected.
- [ ] I have updated the relevant documentation (if applicable).
- [ ] I have added any necessary unit tests.
- [ ] I have checked for and resolved any potential conflicts.
- [x] I have sent an update to the Discord channel regarding these changes. -> Messaged Maksym

## Additional Notes:
Include any additional information that reviewers should be aware of when evaluating this PR.
