### PR TITLE
fix: Contact page banner fixed and consistent with About page

### DIFF
--- a/src/pages/support/contact/index.page.tsx
+++ b/src/pages/support/contact/index.page.tsx
@@ -17,6 +17,9 @@ import styles from '@/app/common.module.css';
 
 import OFFICE_GIRL_3 from '@/assets/images/office-girl-3.png';
 import PNG_HIGHLIGHTEDTIPS from '@/assets/images/contact-card-highlighted-0.png';
+// Use MainBackground to provide a fixed banner effect, matching the About page.
+// This ensures visual consistency and code reuse across pages with banners.
+import { MainBackground } from '@/app/ui/atoms';
 
 type FormData = {
     isAllowedUpdate: boolean | undefined;
@@ -68,15 +71,9 @@ const ContactsPage: FC = () => {
     return (
         <>
             <section className={'flex justify-center w-full'}>
-                <div
-                    className={cn('h-dvh max-h-[62.5rem] w-full max-w-[120rem]', 'relative bg-cover bg-center')}
-                    style={{
-                        backgroundImage: `url(${OFFICE_GIRL_3.src})`,
-                        position: 'relative',
-                        backgroundSize: 'cover',
-                        backgroundPosition: '50% top',
-                    }}
-                >
+                {/* Render the fixed banner background using MainBackground, ensuring consistent scroll behavior and appearance with the About page. */}
+                <div className={cn('h-dvh max-h-[62.5rem] w-full max-w-[120rem]', 'relative')}> 
+                    <MainBackground url={OFFICE_GIRL_3} />
                     <div className={cn(styles.content, 'relative z-10 flex items-start justify-start')}>
                         <div>
                             <h1


### PR DESCRIPTION
# Pull Request: Fix Contact Page Banner Behavior

## Description
This PR updates the Contact page banner to match the fixed scroll behavior of the About and Tidal pages. The banner now remains fixed while scrolling until the content covers it, ensuring visual consistency across these sections.

## Type of Change
Please mark the relevant option(s):
- [* ] Update Feature
- [ ] Add Feature
- [ ] Delete Feature
- [ ] Add File(s)
- [ ] Delete File(s)
- [ ] Other (please specify):

## Checklist:
- [* ] My code adheres to the project guidelines and best practices.
- [ *] I have tested my changes and they work as expected.
- [ ] I have updated the relevant documentation (if applicable).
- [ ] I have added any necessary unit tests.
- [ *] I have checked for and resolved any potential conflicts.
- [ *] I have sent an update to the Discord channel regarding these changes.

## Additional Notes:
The Contact page banner is visually and functionally consistent with the About and Tidal pages.
