### PR TITLE
Fix: Make Contact page banner fixed with consistent layout

### DIFF
--- a/src/app/ui/atoms/MainBackground.tsx
+++ b/src/app/ui/atoms/MainBackground.tsx
@@ -6,27 +6,30 @@ import cn from 'classnames';
 
 // TODO rework to be section + gradients
 interface Props {
-    url: StaticImageData | string;
-    className?: string;
+  url: StaticImageData | string;
+  className?: string;
+  position?: string; // optional override like "top", "center", "center 20%"
 }
 
-const MainBackground: FC<Props> = (props: Props) => {
-    const { className } = props;
-    const url = typeof props.url === 'string' ? props.url : props.url.src;
-    return (
-        <>
-            <div
-                style={{ backgroundImage: `url("${url}")` }}
-                className={cn(
-                    'absolute max-w-dwv min-h-full h-screen max-h-[100rem] w-dvw',
-                    'bg-fixed bg-cover bg-center bottom-0 right-0 top-0',
-                    className,
-                )}
-            />
-        </>
-    );
+const MainBackground: FC<Props> = ({ url, className, position = 'center' }) => {
+  const imageUrl = typeof url === 'string' ? url : url.src;
+
+  return (
+    <div
+      style={{
+        backgroundImage: `url("${imageUrl}")`,
+        backgroundPosition: position,
+      }}
+      className={cn(
+        'absolute max-w-dvw min-h-full h-screen max-h-[100rem] w-dvw',
+        'bg-fixed bg-cover bottom-0 right-0 top-0',
+        className,
+      )}
+    />
+  );
 };
 
 MainBackground.displayName = MainBackground.name;
 
 export { MainBackground };
+

--- a/src/app/ui/atoms/MainBackground.tsx
+++ b/src/app/ui/atoms/MainBackground.tsx
@@ -6,30 +6,27 @@ import cn from 'classnames';
 
 // TODO rework to be section + gradients
 interface Props {
-  url: StaticImageData | string;
-  className?: string;
-  position?: string; // optional override like "top", "center", "center 20%"
+    url: StaticImageData | string;
+    className?: string;
 }
 
-const MainBackground: FC<Props> = ({ url, className, position = 'center' }) => {
-  const imageUrl = typeof url === 'string' ? url : url.src;
-
-  return (
-    <div
-      style={{
-        backgroundImage: `url("${imageUrl}")`,
-        backgroundPosition: position,
-      }}
-      className={cn(
-        'absolute max-w-dvw min-h-full h-screen max-h-[100rem] w-dvw',
-        'bg-fixed bg-cover bottom-0 right-0 top-0',
-        className,
-      )}
-    />
-  );
+const MainBackground: FC<Props> = (props: Props) => {
+    const { className } = props;
+    const url = typeof props.url === 'string' ? props.url : props.url.src;
+    return (
+        <>
+            <div
+                style={{ backgroundImage: `url("${url}")` }}
+                className={cn(
+                    'absolute max-w-dwv min-h-full h-screen max-h-[100rem] w-dvw',
+                    'bg-fixed bg-cover bg-center bottom-0 right-0 top-0',
+                    className,
+                )}
+            />
+        </>
+    );
 };
 
 MainBackground.displayName = MainBackground.name;
 
 export { MainBackground };
-

--- a/src/pages/support/contact/index.page.tsx
+++ b/src/pages/support/contact/index.page.tsx
@@ -71,7 +71,7 @@ const ContactsPage: FC = () => {
             <section className={cn(styles.section, styles.fullHeightSection)}>
                 <MainBackground
                     url={OFFICE_GIRL_3.src}
-                    className="h-screen w-screen bg-cover bg-fixed bg-[center_0%] lg:bg-top"
+                    className="lg:bg-top"
                 />
 
                 <div className={cn(styles.content, 'relative z-10 flex items-start justify-start')}>

--- a/src/pages/support/contact/index.page.tsx
+++ b/src/pages/support/contact/index.page.tsx
@@ -12,7 +12,7 @@ import { ResourceCard } from '@/app/ui/organisms';
 import { ResourcesSection } from '@/app/ui/templates';
 import { PageLink } from '@/app/ui/layout';
 import { Route } from '@/app/static';
-
+import { MainBackground } from '@/app/ui/atoms';
 import styles from '@/app/common.module.css';
 
 import OFFICE_GIRL_3 from '@/assets/images/office-girl-3.png';
@@ -67,34 +67,26 @@ const ContactsPage: FC = () => {
 
     return (
         <>
-            <section className={'flex justify-center w-full'}>
-                <div
-                    className={cn('h-dvh max-h-[62.5rem] w-full max-w-[120rem]', 'relative bg-cover bg-center')}
-                    style={{
-                        backgroundImage: `url(${OFFICE_GIRL_3.src})`,
-                        position: 'relative',
-                        backgroundSize: 'cover',
-                        backgroundPosition: '50% top',
-                    }}
-                >
-                    <div className={cn(styles.content, 'relative z-10 flex items-start justify-start')}>
-                        <div>
-                            <h1
-                                className={cn(
-                                    `w-min text-left leading-n`,
-                                    `mb-n text-96`,
-                                    `lg:x-[w-full,mt-6xl-1]`,
-                                    `md:x-[mt-xl,text-96]`,
-                                    `sm:x-[flex,mt-xs,text-64]`,
-                                )}
-                            >
-                                Contact Tern
-                            </h1>
-                        </div>
+
+            <section className={cn(styles.section, styles.fullHeightSection)}>
+                <MainBackground url={OFFICE_GIRL_3.src} />
+                <div className={cn(styles.content, 'relative z-10 h-full flex flex-col justify-center items-start')}>
+                    <div>
+                        <h1
+                            className={cn(
+                                `w-min text-left leading-n`,
+                                `mb-n text-96`,
+                                `lg:x-[w-full,mt-6xl-1]`,
+                                `md:x-[mt-xl,text-96]`,
+                                `sm:x-[flex,mt-xs,text-64]`,
+                            )}
+                        >
+                            Contact Tern
+                        </h1>
                     </div>
-                    <div className='absolute inset-0 bg-gradient-to-r from-black via-black via-0% lg:via-5% to-transparent  sm:to-60%  md:to-40% lg:to-50% z-0' />
-                    <div className='absolute inset-0 bg-gradient-to-l from-black from-0%   via-black via-0% lg:via-10%   to-transparent to-0% lg:to-20% z-1' />
                 </div>
+                <div className='absolute inset-0 bg-gradient-to-r from-black via-black via-0% lg:via-5% to-transparent  sm:to-60%  md:to-40% lg:to-50% z-0' />
+                <div className='absolute inset-0 bg-gradient-to-l from-black from-0%   via-black via-0% lg:via-10%   to-transparent to-0% lg:to-20% z-1' />
             </section>
 
             <div

--- a/src/pages/support/contact/index.page.tsx
+++ b/src/pages/support/contact/index.page.tsx
@@ -71,7 +71,7 @@ const ContactsPage: FC = () => {
             <section className={cn(styles.section, styles.fullHeightSection)}>
                 <MainBackground
                     url={OFFICE_GIRL_3.src}
-                    position="center top"
+                    className="h-screen w-screen bg-cover bg-fixed bg-[center_0%] lg:bg-top"
                 />
 
                 <div className={cn(styles.content, 'relative z-10 flex items-start justify-start')}>

--- a/src/pages/support/contact/index.page.tsx
+++ b/src/pages/support/contact/index.page.tsx
@@ -69,8 +69,12 @@ const ContactsPage: FC = () => {
         <>
 
             <section className={cn(styles.section, styles.fullHeightSection)}>
-                <MainBackground url={OFFICE_GIRL_3.src} />
-                <div className={cn(styles.content, 'relative z-10 h-full flex flex-col justify-center items-start')}>
+                <MainBackground
+                    url={OFFICE_GIRL_3.src}
+                    position="center top"
+                />
+
+                <div className={cn(styles.content, 'relative z-10 flex items-start justify-start')}>
                     <div>
                         <h1
                             className={cn(


### PR DESCRIPTION
# Pull Request for Website

## Description
Updated the Contact page banner to match the behavior of the About and Tidal pages. Previously, the Contact page banner scrolled away with the content. The new implementation uses the `<MainBackground />` component to keep the image fixed while the content scrolls over it. The heading "Contact Tern" is vertically aligned within the hero section, and gradient overlays are retained for visual consistency.

## Type of Change
Please mark the relevant option(s):
- [x] Update Feature
- [ ] Add Feature
- [ ] Delete Feature
- [ ] Add File(s)
- [ ] Delete File(s)
- [ ] Other (please specify):

## Checklist:
- [x] My code adheres to the project guidelines and best practices.
- [x] I have tested my changes and they work as expected.
- [ ] I have updated the relevant documentation (if applicable).
- [ ] I have added any necessary unit tests.
- [x] I have checked for and resolved any potential conflicts.
- [ ] I have sent an update to the Discord channel regarding these changes.

## Additional Notes:
**How to Test:**
1. Navigate to the Contact page (`/contact`)
2. Verify that the banner image remains fixed during scroll.
3. Confirm that the “Contact Tern” heading is visible and vertically centered.
4. Compare with the About and Tidal pages to ensure consistency.