### PR TITLE
fix: Make Contact page banner fixed like About/Tidal pages (WB-126)

### DIFF
--- a/src/pages/support/contact/index.page.tsx
+++ b/src/pages/support/contact/index.page.tsx
@@ -17,6 +17,7 @@ import styles from '@/app/common.module.css';
 
 import OFFICE_GIRL_3 from '@/assets/images/office-girl-3.png';
 import PNG_HIGHLIGHTEDTIPS from '@/assets/images/contact-card-highlighted-0.png';
+import { MainBackground } from '@/app/ui/atoms';
 
 type FormData = {
     isAllowedUpdate: boolean | undefined;
@@ -68,15 +69,11 @@ const ContactsPage: FC = () => {
     return (
         <>
             <section className={'flex justify-center w-full'}>
-                <div
-                    className={cn('h-dvh max-h-[62.5rem] w-full max-w-[120rem]', 'relative bg-cover bg-center')}
-                    style={{
-                        backgroundImage: `url(${OFFICE_GIRL_3.src})`,
-                        position: 'relative',
-                        backgroundSize: 'cover',
-                        backgroundPosition: '50% top',
-                    }}
-                >
+                <div className={cn('h-dvh max-h-[62.5rem] w-full max-w-[120rem]', 'relative')}>
+                    <MainBackground
+                        url={OFFICE_GIRL_3}
+                        className='bg-[center_top_10%]'
+                    />
                     <div className={cn(styles.content, 'relative z-10 flex items-start justify-start')}>
                         <div>
                             <h1


### PR DESCRIPTION
# Pull Request for Website

## Description
This PR updates the Contact page banner to match the fixed banner behavior found on the About and Tidal pages. Previously, the image on the Contact page scrolled along with the content. It now remains fixed in place while the user scrolls, enhancing visual consistency and aligning with the site's layout standards.

Replaced the previous inline background image logic with the shared <MainBackground /> component.

Adjusted backgroundPosition to visually align the focal area of the image correctly.

Ensured responsive behavior and styling are consistent with About and Tidal pages.



## Type of Change
Please mark the relevant option(s):
- [X] Update Feature
- [ ] Add Feature
- [ ] Delete Feature
- [ ] Add File(s)
- [ ] Delete File(s)
- [ ] Other (please specify):

## Checklist:
- [X] My code adheres to the project guidelines and best practices.
- [X] I have tested my changes and they work as expected.
- [ ] I have updated the relevant documentation (if applicable).
- [ ] I have added any necessary unit tests.
- [X] I have checked for and resolved any potential conflicts.
- [X] I have sent an update to the Discord channel regarding these changes.

## Additional Notes:
Include any additional information that reviewers should be aware of when evaluating this PR.

- No breaking changes were introduced.
- Gradient overlays and z-index structure were preserved.
- This update improves the visual polish and UX of the Contact page across all viewports.


