### PR TITLE
fix: Prevent G Handbook button and paragraph from fading on Tidal page

### DIFF
--- a/src/pages/product/index.page.tsx
+++ b/src/pages/product/index.page.tsx
@@ -153,7 +153,10 @@ function TidalPage() {
                 </div>
             </section>
             <section
-                style={{ backgroundImage: `url("${PNG_BACKGROUND_CIRCUIT.src}")` }}
+                style={{
+                    backgroundImage: `url("${PNG_BACKGROUND_CIRCUIT.src}")`,
+                    zIndex: 'auto',
+                }}
                 className={styles.section}
             >
                 <div


### PR DESCRIPTION

# Pull Request for Website

## Description
This PR addresses the issue where the G Handbook button and the paragraph above it were fading into transparency on the Tidal page.
The fix involved adjusting the stacking context by setting zIndex: 'auto' on the parent section element. This ensured that the gradient overlay no longer obscures the content, preserving full visibility and improving the user experience.

## Type of Change
Please mark the relevant option(s):
- [X] Update Feature
- [ ] Add Feature
- [ ] Delete Feature
- [ ] Add File(s)
- [ ] Delete File(s)
- [ ] Other (please specify):

## Checklist:
- [X] My code adheres to the project guidelines and best practices.
- [X] I have tested my changes and they work as expected.
- [ ] I have updated the relevant documentation (if applicable).
- [ ] I have added any necessary unit tests.
- [X] I have checked for and resolved any potential conflicts.
- [X] I have sent an update to the Discord channel regarding these changes.

## Additional Notes:
- Gradient overlay is preserved and remains visually effective.
- Fix ensures proper visual hierarchy and alignment with Tidal page design.
- No side effects were observed in related sections or viewports.


