### PR TITLE
Fix fadding issue on G handBook and paragraph

### DIFF
--- a/src/pages/product/index.page.tsx
+++ b/src/pages/product/index.page.tsx
@@ -214,7 +214,7 @@ function TidalPage() {
             </section>
             <section
                 ref={demoSectionRef}
-                className={cn(styles.section, styles.sectionShadowBlack)}
+                className={cn(styles.section)}
             >
                 <div
                     className={cn(


### PR DESCRIPTION
# Pull Request for Website

## Description
There was an issue on the Tidal page where the "G Handbook" button and the paragraph above it appeared partially transparent. This was happening due to the `styles.sectionShadowBlack` class. To fix this, I removed the `styles.sectionShadowBlack` style, which resolved the issue and made the elements clearly visible.


## Type of Change
Please mark the relevant option(s):
- [✅] Update Feature
- [ ] Add Feature
- [ ] Delete Feature
- [ ] Add File(s)
- [ ] Delete File(s)
- [ ] Other (please specify):

## Checklist:
- [✅] My code adheres to the project guidelines and best practices.
- [✅] I have tested my changes and they work as expected.
- [ ] I have updated the relevant documentation (if applicable).
- [ ] I have added any necessary unit tests.
- [ ] I have checked for and resolved any potential conflicts.
- [✅] I have sent an update to the Discord channel regarding these changes.

## Additional Notes:
Include any additional information that reviewers should be aware of when evaluating this PR.
