### PR TITLE
fix(WB-126): Make Contact page banner fixed like About/Tidal

### DIFF
--- a/src/pages/support/contact/index.page.tsx
+++ b/src/pages/support/contact/index.page.tsx
@@ -17,6 +17,7 @@ import styles from '@/app/common.module.css';
 
 import OFFICE_GIRL_3 from '@/assets/images/office-girl-3.png';
 import PNG_HIGHLIGHTEDTIPS from '@/assets/images/contact-card-highlighted-0.png';
+import { MainBackground } from '@/app/ui/atoms';
 
 type FormData = {
     isAllowedUpdate: boolean | undefined;
@@ -68,15 +69,16 @@ const ContactsPage: FC = () => {
     return (
         <>
             <section className={'flex justify-center w-full'}>
-                <div
-                    className={cn('h-dvh max-h-[62.5rem] w-full max-w-[120rem]', 'relative bg-cover bg-center')}
-                    style={{
+                <div className={cn('h-dvh max-h-[62.5rem] w-full max-w-[120rem]', 'relative bg-cover bg-center')}>
+                    <MainBackground url={OFFICE_GIRL_3} />
+
+                    {/* style={{
                         backgroundImage: `url(${OFFICE_GIRL_3.src})`,
                         position: 'relative',
                         backgroundSize: 'cover',
                         backgroundPosition: '50% top',
-                    }}
-                >
+                    }} */}
+
                     <div className={cn(styles.content, 'relative z-10 flex items-start justify-start')}>
                         <div>
                             <h1


### PR DESCRIPTION
# Pull Request for Website

## Description
This PR addresses the issue [WB-126] by updating the Contact page banner to match the fixed background behavior of the About and Tidal pages. The banner now uses a full-height bg-fixed image with layered gradients to provide better visual consistency across pages. The title “Contact Tern” is now centered and aligned for all screen sizes.

## Type of Change
Please mark the relevant option(s):
- [ Yes] Update Feature
- [ ] Add Feature
- [ ] Delete Feature
- [ ] Add File(s)
- [ ] Delete File(s)
- [ ] Other (please specify):

## Checklist:
- [ Yes] My code adheres to the project guidelines and best practices.
- [ Yes] I have tested my changes and they work as expected.
- [ ] I have updated the relevant documentation (if applicable).
- [ ] I have added any necessary unit tests.
- [ Yes] I have checked for and resolved any potential conflicts.
- [ Yes] I have sent an update to the Discord channel regarding these changes.

## Additional Notes:
Uses OFFICE_GIRL_3 image as background
Fully mobile responsive
Visual parity confirmed with /about and /subscribe/tidal
To test: go to /support/contact and scroll — background should stay fixed while content scrolls


[WB-126]: https://tern-systems.atlassian.net/browse/WB-126?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ