### PR TITLE
Fix Contact Page Banner Behavior

### DIFF
--- a/src/pages/support/contact/index.page.tsx
+++ b/src/pages/support/contact/index.page.tsx
@@ -69,7 +69,10 @@ const ContactsPage: FC = () => {
         <>
             <section className={'flex justify-center w-full'}>
                 <div
-                    className={cn('h-dvh max-h-[62.5rem] w-full max-w-[120rem]', 'relative bg-cover bg-center')}
+                    className={cn(
+                        'absolute max-w-dwv min-h-full h-screen max-h-[100rem] w-dvw',
+                        'bg-fixed bg-cover bg-center bottom-0 right-0 top-0',
+                    )}
                     style={{
                         backgroundImage: `url(${OFFICE_GIRL_3.src})`,
                         position: 'relative',


### PR DESCRIPTION
# Pull Request for Website

## Description
Task: Fix Contact Page Banner Behavior

On the Contact page, the banner image currently scrolls with the content. In contrast, the banners on the About and Tidal pages remain fixed while the user scrolls up, until the content below covers them.

## Type of Change
Please mark the relevant option(s):
- [ ] Update Feature
- [ ] Add Feature
- [ ] Delete Feature
- [ ] Add File(s)
- [ ] Delete File(s)
- [ ] Other (please specify):

## Checklist:
- [ ] My code adheres to the project guidelines and best practices.
- [ ] I have tested my changes and they work as expected.
- [ ] I have updated the relevant documentation (if applicable).
- [ ] I have added any necessary unit tests.
- [ ] I have checked for and resolved any potential conflicts.
- [ ] I have sent an update to the Discord channel regarding these changes.

## Additional Notes:
Include any additional information that reviewers should be aware of when evaluating this PR.
