### PR TITLE
Fixed the Contact page to remain fixed while the user scrolls up.

### DIFF
--- a/src/pages/support/contact/index.page.tsx
+++ b/src/pages/support/contact/index.page.tsx
@@ -69,12 +69,13 @@ const ContactsPage: FC = () => {
         <>
             <section className={'flex justify-center w-full'}>
                 <div
-                    className={cn('h-dvh max-h-[62.5rem] w-full max-w-[120rem]', 'relative bg-cover bg-center')}
+                    className={cn('h-dvh max-h-[62.5rem] w-full max-w-[120rem]', 'relative bg-cover bg-center bg-fixed')}
                     style={{
                         backgroundImage: `url(${OFFICE_GIRL_3.src})`,
                         position: 'relative',
                         backgroundSize: 'cover',
                         backgroundPosition: '50% top',
+                        backgroundAttachment: 'fixed',
                     }}
                 >
                     <div className={cn(styles.content, 'relative z-10 flex items-start justify-start')}>


### PR DESCRIPTION
# Pull Request for Website

## Description
Fixed the Contact page banner to stay fixed while scrolling, matching the behavior of the About and Tidal pages. To test these changes, navigate to the Contact page and scroll down. You will notice that the banner image stays fixed in position until content scrolls over it. This mimics the the behavior of the About and Tidal pages.

These changes were made in the banner section of the /src/app/pages/support/contact/index.page.tsx file.  

## Type of Change
Please mark the relevant option(s):
- [x ] Update Feature
- [ ] Add Feature
- [ ] Delete Feature
- [ ] Add File(s)
- [ ] Delete File(s)
- [ ] Other (please specify):

## Checklist:
- [ x] My code adheres to the project guidelines and best practices.
- [ x] I have tested my changes and they work as expected.
- [ x] I have updated the relevant documentation (if applicable).
- [ x] I have added any necessary unit tests.
- [ x] I have checked for and resolved any potential conflicts.
- [ x] I have sent an update to the Discord channel regarding these changes.

## Additional Notes:
Include any additional information that reviewers should be aware of when evaluating this PR.
