### PR TITLE
Fix: adjusted the Contact page banner to match the behavior of the About and Tidal Pages

### DIFF
--- a/src/pages/support/contact/index.page.tsx
+++ b/src/pages/support/contact/index.page.tsx
@@ -75,6 +75,8 @@ const ContactsPage: FC = () => {
                         position: 'relative',
                         backgroundSize: 'cover',
                         backgroundPosition: '50% top',
+                        backgroundRepeat: 'no-repeat',
+                        backgroundAttachment: 'fixed',
                     }}
                 >
                     <div className={cn(styles.content, 'relative z-10 flex items-start justify-start')}>


### PR DESCRIPTION
# Pull Request for Website

## Description
This PR updates the Contact page banner so it now behaves consistently with the About and Tidal pages. The banner remains fixed during the initial scroll and then scrolls away with the content. This improves visual consistency across the site.


## Type of Change
Please mark the relevant option(s):
- [x] Update Feature
- [ ] Add Feature
- [ ] Delete Feature
- [ ] Add File(s)
- [ ] Delete File(s)
- [ ] Other (please specify):

## Checklist:
- [x] My code adheres to the project guidelines and best practices.
- [x] I have tested my changes and they work as expected.
- [ ] I have updated the relevant documentation (if applicable).
- [ ] I have added any necessary unit tests.
- [x] I have checked for and resolved any potential conflicts.
- [x] I have sent an update to the Discord channel regarding these changes.

## Additional Notes:
To test: Go to the Contact page and scroll down. The banner should remain fixed at the top and then scroll out as you reach the content, just like on the About and Tidal pages.
