### PR TITLE
Fix Contact Page Banner behavior by setting background to bg-fixed

### DIFF
--- a/src/pages/support/contact/index.page.tsx
+++ b/src/pages/support/contact/index.page.tsx
@@ -69,7 +69,7 @@ const ContactsPage: FC = () => {
         <>
             <section className={'flex justify-center w-full'}>
                 <div
-                    className={cn('h-dvh max-h-[62.5rem] w-full max-w-[120rem]', 'relative bg-cover bg-center')}
+                    className={cn('h-dvh max-h-[62.5rem] w-full max-w-[120rem]', 'relative bg-fixed bg-center')}
                     style={{
                         backgroundImage: `url(${OFFICE_GIRL_3.src})`,
                         position: 'relative',


### PR DESCRIPTION
# Pull Request for Website

## Description
Fixed the Contact page banner behavior to match the visual behavior of the About and Tidal pages. The banner image is now fixed and no longer scrolls with the content, ensuring a consistent user experience across pages.

This change addresses the issue outlined in task WB-126.

## Type of Change
Please mark the relevant option(s):
- [X ] Update Feature
- [ ] Add Feature
- [ ] Delete Feature
- [ ] Add File(s)
- [ ] Delete File(s)
- [ ] Other (please specify):

## Checklist:
- [ X ] My code adheres to the project guidelines and best practices.
- [X ] I have tested my changes and they work as expected.
- [ ] I have updated the relevant documentation (if applicable).
- [ ] I have added any necessary unit tests.
- [X ] I have checked for and resolved any potential conflicts.
- [X ] I have sent an update to the Discord channel regarding these changes.

## Additional Notes:
How to Test the Fix:
- Visit the Contact page.
- Scroll the page vertically.
- Observe that the banner image remains fixed in place and does not scroll with the content.
- Test across multiple screen sizes (mobile, tablet, desktop) to ensure responsiveness and consistent banner behavior.
