### PR TITLE
Fix: Update Contact banner to be fixed during scroll to maintain cons…

### DIFF
--- a/src/pages/support/contact/index.page.tsx
+++ b/src/pages/support/contact/index.page.tsx
@@ -17,6 +17,7 @@ import styles from '@/app/common.module.css';
 
 import OFFICE_GIRL_3 from '@/assets/images/office-girl-3.png';
 import PNG_HIGHLIGHTEDTIPS from '@/assets/images/contact-card-highlighted-0.png';
+import { MainBackground } from '@/app/ui/atoms';
 
 type FormData = {
     isAllowedUpdate: boolean | undefined;
@@ -67,15 +68,14 @@ const ContactsPage: FC = () => {
 
     return (
         <>
-            <section className={'flex justify-center w-full'}>
+            <section className={cn(styles.section, styles.fullHeightSection)}>
+                <MainBackground url={OFFICE_GIRL_3.src} /> {/* Update with the contact page background image */}
                 <div
-                    className={cn('h-dvh max-h-[62.5rem] w-full max-w-[120rem]', 'relative bg-cover bg-center')}
-                    style={{
-                        backgroundImage: `url(${OFFICE_GIRL_3.src})`,
-                        position: 'relative',
-                        backgroundSize: 'cover',
-                        backgroundPosition: '50% top',
-                    }}
+                    className={cn(
+                        styles.content,
+                        'relative flex justify-end z-10',
+                        'items-start md:items-center lg:items-center',
+                    )}
                 >
                     <div className={cn(styles.content, 'relative z-10 flex items-start justify-start')}>
                         <div>


### PR DESCRIPTION
…istency with About and Tidal Page

# Pull Request for Website

## Description
This PR fixes the behavior of the banner on the Contact page to match the fixed banner behavior found on the About and Tidal pages. Previously, the banner image on the Contact page scrolled with the content. Now, it remains fixed while the user scrolls up, until the content below covers it. This change ensures visual consistency across the website in all viewports.

## Type of Change
Please mark the relevant option(s):
- [X] Update Feature
- [ ] Add Feature
- [ ] Delete Feature
- [ ] Add File(s)
- [ ] Delete File(s)
- [ ] Other (please specify):

## Checklist:
- [X] My code adheres to the project guidelines and best practices.
- [x] I have tested my changes and they work as expected.
- [x] I have updated the relevant documentation (if applicable).
- [X] I have added any necessary unit tests.
- [X] I have checked for and resolved any potential conflicts.
- [X] I have sent an update to the Discord channel regarding these changes.

## Additional Notes:
How to Test:
1. **Navigate to the Contact page** on the website.
2. **Scroll up** on the page and observe the banner behavior. 
   - The banner should remain fixed while the user scrolls up.
   - Once the content below the banner reaches the top of the screen, it should cover the banner.
3. **Check across multiple viewports**:
   - Desktop: Ensure the banner behaves as expected on larger screens.
   - Tablet: Verify that the banner remains fixed while scrolling on tablet-sized screens.
   - Mobile: Confirm that the banner remains fixed and the content covers it when scrolling on mobile devices.

 Expected Outcome:
- The Contact page banner should have the same scrolling behavior as the About and Tidal pages, providing a consistent experience for users across different sections of the website.
